### PR TITLE
draft manifest.ijs

### DIFF
--- a/manifest.ijs
+++ b/manifest.ijs
@@ -1,0 +1,18 @@
+NB. to use:
+NB.   install 'pascal-j/kv@main'
+
+CAPTION=: 'key value dictionary'
+
+DESCRIPTION=: 0 : 0
+  A nestable 'dictionary' abstraction, using J symbols and locales
+)
+
+VERSION=: '1.0.0'
+
+RELEASE=: ''
+
+FOLDER=: 'pascal-j/kv'
+
+FILES=: 0 : 0
+kv.ijs
+)


### PR DESCRIPTION
Currently, trying to install pascal-j/kv fails, because you are missing a manifest.

This manifest should support installation of your kv, directly from github.
 
I am not yet sure whether this would be sufficient:

   require'pascal-j/kv'

or whether this would be needed:

   require'~addons/pascal-j/kv/kv.ijs'

That said, it would be nice if you could move the startup testing which we currently get when loading kv.ijs to a second script, with comments in the readme to get people started.